### PR TITLE
Fix negative number issue, only add pairs in proper temporal order

### DIFF
--- a/dsl/timeline.go
+++ b/dsl/timeline.go
@@ -163,7 +163,7 @@ func (t Timelines) EntryPairs(index int) EntryPairs {
 	pairs := EntryPairs{}
 	for _, timeline := range t {
 		pair, ok := timeline.EntryPair(index)
-		if ok {
+		if ok && pair.FirstEntry.Timestamp.Before(pair.SecondEntry.Timestamp) {
 			pairs = append(pairs, pair)
 		}
 	}
@@ -174,13 +174,7 @@ func (t Timelines) EntryPairs(index int) EntryPairs {
 func (t Timelines) DTStatsSlice() DTStatsSlice {
 	dtStats := []DTStats{}
 	for i, timelinePoint := range t.Description() {
-		pairs := EntryPairs{}
-		for _, timeline := range t {
-			pair, ok := timeline.EntryPair(i)
-			if ok {
-				pairs = append(pairs, pair)
-			}
-		}
+		pairs := t.EntryPairs(i)
 		stats := pairs.DTStats()
 		stats.Name = timelinePoint.Name
 		dtStats = append(dtStats, stats)


### PR DESCRIPTION
E.g. if event-stream-processor fails to log start but logs finish,
and bulker logs start but fails to log successful finish (because
event-stream-processor already did it), and event-stream-processor
finishes before bulker tries to start, the current matchers will
make it appear that the task process finished before it started,
contributing to negative times in the histogram.
