### PR TITLE
Reject incomplete timelines

### DIFF
--- a/dsl/timeline.go
+++ b/dsl/timeline.go
@@ -184,6 +184,7 @@ func (t Timelines) DTStatsSlice() DTStatsSlice {
 
 func (t Timelines) StartsAfter() time.Duration {
 	min := time.Hour * 100000
+
 	for _, timeline := range t {
 		dt := timeline.BeginsAt().Sub(timeline.ZeroEntry.Timestamp)
 		if dt < min {


### PR DESCRIPTION
- Fixes issue where some timelines start at the epoch, messing up the timeline graphs
- We have a simple script that uses bosh and veritas to create input for cicerone that does not suffer from Papertrail lossiness

Signed-off-by: Chris Brown cbrown@pivotal.io
